### PR TITLE
🐛 修复: 无法正确获取 `IS_CHINA_SITE` 环境变量

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,5 @@
     "engines": {
         "node": ">=18.0"
     },
-    "packageManager": "pnpm@10.12.1"
+    "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
 }

--- a/src/components/GlobalContent.js
+++ b/src/components/GlobalContent.js
@@ -1,15 +1,13 @@
 import React from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
-const IS_CHINA_SITE = process.env.CHINA === "true";
-
 /**
- * A component that conditionally renders its children based on the CHINA environment variable.
- * If CHINA is 'true', the children (typically Markdown content) will not be rendered.
+ * A component that conditionally renders its children based on the `IS_CHINA_SITE` environment variable.
+ * If `IS_CHINA_SITE` is 'true', the children (typically Markdown content) will not be rendered.
  */
 export default function GlobalContent({ children }) {
-    if (IS_CHINA_SITE) {
-        return null; // Do not render children if in China site context
+    if (useDocusaurusContext().siteConfig.customFields.IS_CHINA_SITE) {
+        return null; // Do not render children if in the China site context
     }
     return <>{children}</>; // Render children otherwise
 }


### PR DESCRIPTION
修复浏览 `/services` 页面时无法获取 NodeJS的 process 从而无法正确获取 IS_CHINA_SITE 环境变量，参考 https://docusaurus.io/docs/deployment#using-environment-variables

<img width="1041" height="420" alt="截屏2025-11-30 00 02 36" src="https://github.com/user-attachments/assets/f66b51c9-8149-40e7-bbdd-ef38a9171f04" />
