### PR TITLE
修复代码高亮块上的展开/复制按钮无法使用

### DIFF
--- a/src/css/components/code.css
+++ b/src/css/components/code.css
@@ -23,7 +23,6 @@ code {
     font-size: 0.875rem;
     line-height: 1.7;
     position: relative;
-    z-index: 1;
 }
 
 pre code {


### PR DESCRIPTION
移除 code block 样式内不必要的 z-index

z-index 是用来规定重叠元素的层级关系的。两个按钮的 z-index 都是 auto，而这里的 code block 的 z-index 错误的规定为 1，会导致 code block 的元素覆盖按钮的元素，进而导致无法选中，视觉上就是点不动无法使用。

参考 https://developer.mozilla.org/zh-CN/docs/Web/CSS/Reference/Properties/z-index