### PR TITLE
添加EnableX86ECoreOpts JVM参数

### DIFF
--- a/src/content/docs/java/advance/optimize/jvm/common.md
+++ b/src/content/docs/java/advance/optimize/jvm/common.md
@@ -54,6 +54,14 @@ java -Xlog:gc+init -XX:+UseTransparentHugePages -Xmx1g -version
 --add-modules=jdk.incubator.vector
 ```
 
+## E 核优化
+
+如果你使用 Java 22+、处理器为 x86_64 平台且存在大小核（P 核 + E 核）架构，你可以添加此参数
+
+```txt
+-XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts
+```
+
 ## 下载源加速
 
 默认的 SpigotLibraryLoader 下载源或插件使用 PaperLibraryLoader 添加的 Maven 中心仓库下载源在国内访问很慢，


### PR DESCRIPTION
只是一个小零食级别的JVM参数罢了。
在我的CPU上（Intel U7 255HX）获得约5%的提升（超平坦512村民，mspt 9.4 -> 8.9）。
_本来这个参数应该自动启用，但由于在JVM内部这个的判断是硬编码的，导致我较新的Arrow Lake无法自动启用，参见[https://bugs.openjdk.org/browse/JDK-8374926](https://bugs.openjdk.org/browse/JDK-8374926)，故专门点出。_