### PR TITLE
针对Java-生电-插件端中paper-global.yml内容修改

### DIFF
--- a/src/content/docs/java/process/redstone/plugin.md
+++ b/src/content/docs/java/process/redstone/plugin.md
@@ -68,8 +68,8 @@ misc:
     max-joins-per-tick: 2147483647 # 每个 Tick 允许的最大加入玩家数，超出则延迟加入（与 bukkit.yml 中的连接节流无关）
 packet-limiter:
     all-packets:
-        interval: 0.000001 # 最大数据包速率生效的时间间隔（单位：秒）
-        max-packet-rate: 999999.0 # 每个玩家在上述时间间隔内允许的最大数据包数量
+        interval: 7 # 最大数据包速率生效的时间间隔（单位：秒）
+        max-packet-rate: 500 # 每个玩家在上述时间间隔内允许的最大数据包数量
 spam-limiter:
     incoming-packet-threshold: 2147483647 # 收到的数据包超过此阈值时视为垃圾流量并忽略
 unsupported-settings:


### PR DESCRIPTION
经过测试，在这一段内容的修改，会导致客户端无法与服务端建立连接，原因是数据包根本无法反应，具体实际效果如下
<img width="1263" height="174" alt="image" src="https://github.com/user-attachments/assets/90c914b6-ca60-47e1-b6ba-02ac5f341b80" />
在修改后，出现一下情况，服务器ping包错误，客户端接收到的ping包不完整，强行停止运行剩余流程
并且连接到服务器时，提示连接中断
所以，我认为这一段应该修改为如下，保证正常运行
测试环境：paper-1.21.11-123