### PR TITLE
更新 Dopamine 支持的版本

### DIFF
--- a/src/content/docs/java/process/mobile-player/client/amethyst-ios.mdx
+++ b/src/content/docs/java/process/mobile-player/client/amethyst-ios.mdx
@@ -254,7 +254,7 @@ import { Steps } from "@astrojs/starlight/components";
 
 \*Dopamine 到 iOS 16.6 - 16.6.1 不支持 A12 及更新版本的设备，iOS 16.5.1 - 16.7 不支持 A15-A16/M2 版本的设备。
 
-使用 DarkSword 漏洞 15.8.7 在 A9 - A10 设备上可以使用 Dopamine ， 16.7 - 16.7.15 arm64设备可以使用 Dopamine ， 目前 A8(X) 设备不支持 ， 在 A9X 设备上可能无法工作 ， 不要在 16.0 – 16.3.1 使用这个漏洞
+使用 DarkSword 漏洞 15.8.7 在 A9 - A10 设备上可以使用 Dopamine，16.7 - 16.7.15 arm64 设备可以使用 Dopamine，目前 A8（X）设备不支持，在 A9X 设备上可能无法工作，不要在 16.0 – 16.3.1 使用这个漏洞。
 
 除了 Palera1n 和 Checkra1n 需要使用 U 盘或者 Linux 或者 macOS，其他基本上就是像 Dopamine 那样的安装方法。
 


### PR DESCRIPTION
opa334 发布了[2.5 Beta 1](https://github.com/opa334/Dopamine/releases/tag/2.5b1)，在这个版本里增加了 iOS 15.8.7 (A9-A10) 和 iOS 16.7 - 16.7.15 (arm64) 的支持