### PR TITLE
关闭 CN 访问自动跳转

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,7 +14,7 @@ import vue from "@astrojs/vue";
 const IS_CHINA_SITE = process.env.CHINA === "true";
 
 export default defineConfig({
-    site: IS_CHINA_SITE ? "https://nitwikit.8aka.cn" : "https://nitwikit.8aka.org",
+    //site: IS_CHINA_SITE ? "https://nitwikit.8aka.cn" : "https://nitwikit.8aka.org", // 等 cn 镜像站修好了再启用
     outDir: "./build",
     integrations: [
         vue(),

--- a/src/content/docs/java/process/mobile-player/client/amethyst-ios.mdx
+++ b/src/content/docs/java/process/mobile-player/client/amethyst-ios.mdx
@@ -334,7 +334,7 @@ import { Steps } from "@astrojs/starlight/components";
 
 <Steps>
 
-1. 你需要查看 [**安装 TrollStore**](https://nitwikit.8aka.cn/java/process/mobile-player/client/amethyst-ios/#%E5%AE%89%E8%A3%85-trollstore) 第一个方法 1~11 步，将 Dopamine 安装到你的手机上
+1. 你需要查看 [**安装 TrollStore**](#安装-trollstore) 第一个方法 1~11 步，将 Dopamine 安装到你的手机上
 
 2. 打开 Dopamine，点击越狱按钮，选择包管理器为 Sideo，设置 root 密码
 


### PR DESCRIPTION
鉴于 .cn 镜像站的问题至今未修复，因此关闭国内访问跳转的机制。同时修了一个错误的内链引用