### PR TITLE
🐛 fix: 修复 keep-running.mdx 指令格式错误显示问题

### DIFF
--- a/src/content/docs/general/advance/linux/keep-running.mdx
+++ b/src/content/docs/general/advance/linux/keep-running.mdx
@@ -17,9 +17,21 @@ import { TabItem, Tabs } from "@astrojs/starlight/components";
 确保你的系统上有 `screen` 包，没有的话安装它们：
 
 <Tabs>
-    <TabItem label="Debian/Ubuntu">```bash apt-get install screen ```</TabItem>
-    <TabItem label="CentOS/RHEL">```bash yum install screen ```</TabItem>
-    <TabItem label="Arch Linux">```bash pacman -Sy screen ```</TabItem>
+    <TabItem label="Debian/Ubuntu">
+    ```bash 
+    apt-get install screen 
+    ```
+    </TabItem>
+    <TabItem label="CentOS/RHEL">
+    ```bash 
+    yum install screen 
+    ```
+     </TabItem>
+    <TabItem label="Arch Linux">
+    ```bash 
+    pacman -Sy screen 
+    ```
+    </TabItem>
 </Tabs>
 
 screen 的基础指令：


### PR DESCRIPTION
<img width="506" height="274" alt="image" src="https://github.com/user-attachments/assets/a5a8bc5e-cfb0-41e1-91af-c2862d109f91" />

⬇️

<img width="506" height="274" alt="image" src="https://github.com/user-attachments/assets/568eb901-e009-4d10-9e7e-4e2353550ee4" />
