### PR TITLE
:memo: 修正 `可安装在跨服端或子服` 中的错别字

### DIFF
--- a/src/content/docs/java/process/cross-server/plugin/proxy-backend-optional.mdx
+++ b/src/content/docs/java/process/cross-server/plugin/proxy-backend-optional.mdx
@@ -219,7 +219,7 @@ TODO
 ![BungeeCord](https://img.shields.io/badge/BungeeCord-orange?&style=for-the-badge)
 ![Velocity](https://img.shields.io/badge/Velocity-blue?&style=for-the-badge)
 
-SkinRestorer 拥有完善的 Proxy Mode 以支持在代理服与字符同时部署，其本身作为老牌皮肤插件并无其他明显缺点。
+SkinRestorer 拥有完善的 Proxy Mode 以支持在代理服与子服同时部署，其本身作为老牌皮肤插件并无其他明显缺点。
 
 <Tabs queryString="SkinsRestorer">
   <TabItem value="good" label="好处">


### PR DESCRIPTION
'子服'写成'字'